### PR TITLE
BUGFIX: root_dir in MRI dataset

### DIFF
--- a/src/configs/base/mri_mae_model.yaml
+++ b/src/configs/base/mri_mae_model.yaml
@@ -1,6 +1,6 @@
-experiment_name: "mri_mae_model_t1c_mask_ratio_0.0"
+experiment_name: "mri_mae_model_test"
 splits: 5
-n_epochs: 100
+n_epochs: 50
 
 n_intervals: 20
 random_seed: 1380

--- a/src/configs/data/mri_mae.yaml
+++ b/src/configs/data/mri_mae.yaml
@@ -2,4 +2,4 @@ mri:
   sizes: [64, 64, 64]
   modalities: ["t1c"] # ["t1c","t1n","t2w","t2f"]
   tensor_name : "roi"
-  root_path: "/data/BraTS_2023/MRI"
+  root_path: "/mnt/data/d.kornilov/BraTS_2023/MRI"

--- a/src/unimodal/mri/datasets.py
+++ b/src/unimodal/mri/datasets.py
@@ -189,9 +189,11 @@ class MRIDataset(BaseDataset):
             mask = True
             item = None
             if self.tensor_name is not None:
+                patient_tag = sample.split(os.sep)[-1]
                 item = torch.load(
                     os.path.join(
-                        sample,
+                        self.root_dir,
+                        patient_tag,
                         f"{self.tensor_name}_{'_'.join(self.modality)}_{'_'.join(list(map(str, self.sizes)))}.pt"
                     ),
                     weights_only=False


### PR DESCRIPTION
Fixed usage of root_dir when loading tensors in MRI dataset